### PR TITLE
feat: Allow API keys in request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,17 @@ All endpoints are prefixed with `/api`.
 
 ### **Authentication**
 
-This API uses a two-key system for security and session management:
+This API uses a two-key system for security and session management. Both keys can be provided in either the request header or the request body for `POST` requests, giving you more flexibility. For `GET` requests, they must be in the header.
 
 1.  **Master Key (`X-MASTER-KEY`)**:
-    -   This is a global key that grants access to the API server.
-    -   It must be included in the header of **every single request**.
+    -   This is a global key that grants access to the entire API server.
+    -   It can be included in the `X-MASTER-KEY` header or as a field in the JSON request body. The header will always take precedence if both are provided.
     -   This is the key you set in your `.env` file.
 
 2.  **Session Key (`X-API-KEY`)**:
     -   This key identifies a specific WhatsApp session (i.e., a specific phone number).
+    -   For `POST` requests, it can be in the `X-API-KEY` header or a field in the JSON/form-data body.
+    -   For `GET` requests, it must be in the `X-API-KEY` header.
     -   You can invent any unique string for each session (e.g., `user1_phone`, `work_account`, a random hash, etc.).
     -   The first time a new `X-API-KEY` is used with the `/connect` endpoint, a new session will be created for it.
 
@@ -266,12 +268,12 @@ Once connected, the server will save the session data in the `./sessions` folder
 #### 5. **Send Text Message (POST)**
 
 -   **Endpoint**: `POST /send-message`
--   **Headers**:
-    -   `X-MASTER-KEY: your_global_master_key_here`
-    -   `X-API-KEY: your_unique_session_key`
+-   **Headers**: `X-MASTER-KEY: your_global_master_key_here`
+-   **Description**: Sends a plain text message. The `X-API-KEY` can be in the header or, as shown below, in the request body.
 -   **Payload**: `application/json`
     ```json
     {
+      "X-API-KEY": "your_unique_session_key",
       "to": "+1234567890",
       "message": "Hello from the API!"
     }
@@ -281,16 +283,16 @@ Once connected, the server will save the session data in the `./sessions` folder
 
 -   **Endpoint**: `POST /send-attachment`
 -   **Description**: Sends an attachment to a specified number. This endpoint supports three methods: direct file upload, from a URL, or from a Base64 string.
--   **Headers**:
-    -   `X-MASTER-KEY: your_global_master_key_here`
-    -   `X-API-KEY: your_unique_session_key`
+-   **Headers**: `X-MASTER-KEY: your_global_master_key_here`
 
 ---
 
 ##### **Method 1: Direct File Upload**
 
 -   **Content-Type**: `multipart/form-data`
+-   **Description**: The `X-API-KEY` can be in the header or, as shown below, as a form field.
 -   **Body Fields**:
+    -   `X-API-KEY`: Your unique session key.
     -   `to`: The recipient's phone number.
     -   `file`: The file to be sent.
     -   `caption` (optional): A caption for the file.
@@ -298,7 +300,7 @@ Once connected, the server will save the session data in the `./sessions` folder
     ```bash
     curl -X POST http://localhost:3000/api/send-attachment \
     -H "X-MASTER-KEY: your_global_master_key_here" \
-    -H "X-API-KEY: your_unique_session_key" \
+    -F "X-API-KEY=your_unique_session_key" \
     -F "to=+1234567890" \
     -F "file=@/path/to/your/document.pdf" \
     -F "caption=Here is the document you requested."
@@ -309,9 +311,11 @@ Once connected, the server will save the session data in the `./sessions` folder
 ##### **Method 2: From URL or Base64**
 
 -   **Content-Type**: `application/json`
+-   **Description**: The `X-API-KEY` can be in the header or, as shown below, in the request body.
 -   **Payload**:
     ```json
     {
+      "X-API-KEY": "your_unique_session_key",
       "to": "+1234567890",
       "file": "url_or_base64_string",
       "type": "image/png", // Required only for Base64
@@ -326,8 +330,7 @@ Once connected, the server will save the session data in the `./sessions` folder
     curl -X POST http://localhost:3000/api/send-attachment \
     -H "Content-Type: application/json" \
     -H "X-MASTER-KEY: your_global_master_key_here" \
-    -H "X-API-KEY: your_unique_session_key" \
-    -d '{"to": "+1234567890", "file": "https://i.imgur.com/some-image.jpeg", "caption": "From a URL"}'
+    -d '{"X-API-KEY": "your_unique_session_key", "to": "+1234567890", "file": "https://i.imgur.com/some-image.jpeg", "caption": "From a URL"}'
     ```
 
 ---

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,14 +1,6 @@
 const qrcode = require('qrcode');
 const { getStatus, initializeClient } = require('../services/sessionManager');
-
-/**
- * Extracts the session ID from the request headers.
- * @param {import('express').Request} req - The Express request object.
- * @returns {string|null} The session ID or null if not found.
- */
-const getSessionId = (req) => {
-    return req.get('X-API-KEY');
-};
+const { getSessionId } = require('../utils/apiKeyExtractor');
 
 /**
  * Handles the /connect endpoint.

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -1,13 +1,5 @@
 const { sendMessage, sendAttachment } = require('../services/sessionManager');
-
-/**
- * Extracts the session ID from the request headers.
- * @param {import('express').Request} req - The Express request object.
- * @returns {string|null} The session ID or null if not found.
- */
-const getSessionId = (req) => {
-    return req.get('X-API-KEY');
-};
+const { getSessionId } = require('../utils/apiKeyExtractor');
 
 /**
  * Handles the /send-message endpoint.

--- a/src/middleware/masterAuthMiddleware.js
+++ b/src/middleware/masterAuthMiddleware.js
@@ -4,9 +4,11 @@ const MASTER_API_KEY = process.env.MASTER_API_KEY;
 
 /**
  * Middleware to protect all API routes with a Master API key.
+ * The key can be provided in the 'X-MASTER-KEY' header or in the request body.
  */
 const masterApiKeyAuth = (req, res, next) => {
-    const masterKey = req.get('X-MASTER-KEY');
+    // Check for the key in the header first, then in the body.
+    const masterKey = req.get('X-MASTER-KEY') || (req.body ? req.body['X-MASTER-KEY'] : undefined);
 
     if (!MASTER_API_KEY) {
         // If the master key is not set in the environment, deny all requests.

--- a/src/utils/apiKeyExtractor.js
+++ b/src/utils/apiKeyExtractor.js
@@ -1,0 +1,23 @@
+/**
+ * Extracts the session ID (API key) from the request.
+ * It checks the 'X-API-KEY' header first, then falls back to the request body.
+ *
+ * @param {import('express').Request} req - The Express request object.
+ * @returns {string|null} The session ID or null if not found.
+ */
+const getSessionId = (req) => {
+    const fromHeader = req.get('X-API-KEY');
+    if (fromHeader) {
+        return fromHeader;
+    }
+
+    if (req.body && req.body['X-API-KEY']) {
+        return req.body['X-API-KEY'];
+    }
+
+    return null;
+};
+
+module.exports = {
+    getSessionId,
+};

--- a/whatsapp_api_collection.json
+++ b/whatsapp_api_collection.json
@@ -1,216 +1,238 @@
 {
-  "info": {
-    "_postman_id": "a8d1a7d3-2e2e-4b1a-9b7a-0a2b1a1b1b1b",
-    "name": "Simple WhatsApp API",
-    "description": "Postman collection for the Simple WhatsApp API. This collection includes examples for each endpoint and a pre-request script to handle authentication. Set the `MASTER_API_KEY` in your Postman environment to use your own key, or it will default to `SUPER_SECRET_KEY`.",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-  },
-  "item": [
-    {
-      "name": "Authentication",
-      "item": [
-        {
-          "name": "Get QR Code (String)",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/connect",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "connect"
-              ]
-            },
-            "description": "Establishes a new WhatsApp session and returns the QR code as a string for authentication."
-          },
-          "response": []
-        },
-        {
-          "name": "Get QR Code (Image)",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/connect/image",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "connect",
-                "image"
-              ]
-            },
-            "description": "Establishes a new WhatsApp session and returns the QR code as a PNG image."
-          },
-          "response": []
-        }
-      ],
-      "description": "API endpoints for authentication and session management"
+    "info": {
+        "_postman_id": "a8d1a7d3-2e2e-4b1a-9b7a-0a2b1a1b1b1b",
+        "name": "Simple WhatsApp API",
+        "description": "Postman collection for the Simple WhatsApp API. This collection includes examples for each endpoint and a pre-request script to handle authentication.\n\n**Authentication:**\n- **X-MASTER-KEY**: This global key protects the entire server. It can be provided in the `X-MASTER-KEY` header or in the request body. Set the `MASTER_API_KEY` variable in your Postman environment to automatically include it in the header of every request.\n- **X-API-KEY**: This session-specific key identifies a WhatsApp session. For GET requests, it must be in the `X-API-KEY` header. For POST requests, it can be in the header or the request body. Set the `X_API_KEY` variable in your environment to automatically include it in the header.",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
     },
-    {
-      "name": "Messaging",
-      "item": [
+    "item": [
         {
-          "name": "Send Text Message",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
+            "name": "Authentication",
+            "item": [
+                {
+                    "name": "Get QR Code (String)",
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{baseUrl}}/api/connect",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "api",
+                                "connect"
+                            ]
+                        },
+                        "description": "Establishes a new WhatsApp session and returns the QR code as a string. Requires the `X-API-KEY` header (set the `X_API_KEY` environment variable)."
+                    },
+                    "response": []
+                },
+                {
+                    "name": "Get QR Code (Image)",
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{baseUrl}}/api/connect/image",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "api",
+                                "connect",
+                                "image"
+                            ]
+                        },
+                        "description": "Establishes a new WhatsApp session and returns the QR code as a PNG image. Requires the `X-API-KEY` header (set the `X_API_KEY` environment variable)."
+                    },
+                    "response": []
+                }
             ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"number\": \"1234567890\",\n  \"message\": \"Hello from the API!\"\n}"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/send-message",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "send-message"
-              ]
-            },
-            "description": "Sends a text message to a specified number."
-          },
-          "response": []
+            "description": "API endpoints for authentication and session management"
         },
         {
-          "name": "Send Attachment",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
+            "name": "Messaging",
+            "item": [
                 {
-                  "key": "number",
-                  "value": "1234567890",
-                  "type": "text"
+                    "name": "Send Text Message",
+                    "request": {
+                        "method": "POST",
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            }
+                        ],
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n    \"X-API-KEY\": \"your_session_key_here\",\n    \"to\": \"+1234567890\",\n    \"message\": \"Hello from the API!\"\n}",
+                            "options": {
+                                "raw": {
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "url": {
+                            "raw": "{{baseUrl}}/api/send-message",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "api",
+                                "send-message"
+                            ]
+                        },
+                        "description": "Sends a text message to a specified number. The `X-API-KEY` can be provided in the header (if the `X_API_KEY` environment variable is set) or in the request body."
+                    },
+                    "response": []
                 },
                 {
-                  "key": "caption",
-                  "value": "Check out this cool file!",
-                  "type": "text"
+                    "name": "Send Attachment (Upload)",
+                    "request": {
+                        "method": "POST",
+                        "header": [],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": [
+                                {
+                                    "key": "X-API-KEY",
+                                    "value": "your_session_key_here",
+                                    "type": "text",
+                                    "description": "Session key if not in header"
+                                },
+                                {
+                                    "key": "to",
+                                    "value": "+1234567890",
+                                    "type": "text"
+                                },
+                                {
+                                    "key": "caption",
+                                    "value": "Check out this cool file!",
+                                    "type": "text"
+                                },
+                                {
+                                    "key": "file",
+                                    "type": "file",
+                                    "src": []
+                                }
+                            ]
+                        },
+                        "url": {
+                            "raw": "{{baseUrl}}/api/send-attachment",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "api",
+                                "send-attachment"
+                            ]
+                        },
+                        "description": "Sends an attachment by uploading a file directly. The `X-API-KEY` can be provided in the header or as a form field."
+                    },
+                    "response": []
                 },
                 {
-                  "key": "file",
-                  "type": "file",
-                  "src": []
+                    "name": "Send Message (GET)",
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{baseUrl}}/api/send?number=+1234567890&message=Hello via GET",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "api",
+                                "send"
+                            ],
+                            "query": [
+                                {
+                                    "key": "number",
+                                    "value": "+1234567890"
+                                },
+                                {
+                                    "key": "message",
+                                    "value": "Hello via GET"
+                                }
+                            ]
+                        },
+                        "description": "Sends a message using a GET request. Requires the `X-API-KEY` header (set the `X_API_KEY` environment variable)."
+                    },
+                    "response": []
                 }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/send-attachment",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "send-attachment"
-              ]
-            },
-            "description": "Sends a message with an attachment."
-          },
-          "response": []
+            ],
+            "description": "API endpoints for sending messages"
         },
         {
-          "name": "Send Message (GET)",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/send?number=1234567890&message=Hello via GET",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "send"
-              ],
-              "query": [
+            "name": "File Upload",
+            "item": [
                 {
-                  "key": "number",
-                  "value": "1234567890"
-                },
-                {
-                  "key": "message",
-                  "value": "Hello via GET"
+                    "name": "Upload File",
+                    "request": {
+                        "method": "POST",
+                        "header": [],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": [
+                                {
+                                    "key": "file",
+                                    "type": "file",
+                                    "src": []
+                                }
+                            ]
+                        },
+                        "url": {
+                            "raw": "{{baseUrl}}/api/upload",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "api",
+                                "upload"
+                            ]
+                        },
+                        "description": "Uploads a file to the server to get a temporary URL. This endpoint does not require an `X-API-KEY`."
+                    },
+                    "response": []
                 }
-              ]
-            },
-            "description": "Sends a message using a GET request."
-          },
-          "response": []
+            ],
+            "description": "API endpoints for file uploads"
         }
-      ],
-      "description": "API endpoints for sending messages"
-    },
-    {
-      "name": "File Upload",
-      "item": [
+    ],
+    "event": [
         {
-          "name": "Upload File",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
-                {
-                  "key": "file",
-                  "type": "file",
-                  "src": []
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/upload",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "upload"
-              ]
-            },
-            "description": "Uploads a file to the server."
-          },
-          "response": []
+            "listen": "prerequest",
+            "script": {
+                "type": "text/javascript",
+                "exec": [
+                    "// This script runs before every request in the collection.",
+                    "// It adds authentication headers from your Postman environment.",
+                    "",
+                    "// Add the global Master API Key from the 'MASTER_API_KEY' environment variable.",
+                    "const masterKey = pm.environment.get('MASTER_API_KEY') || 'SUPER_SECRET_KEY';",
+                    "pm.request.headers.add({",
+                    "    key: 'X-MASTER-KEY',",
+                    "    value: masterKey",
+                    "});",
+                    "",
+                    "// Add the session-specific API Key from the 'X_API_KEY' environment variable.",
+                    "const sessionKey = pm.environment.get('X_API_KEY');",
+                    "if (sessionKey) {",
+                    "    pm.request.headers.add({",
+                    "        key: 'X-API-KEY',",
+                    "        value: sessionKey",
+                    "    });",
+                    "}"
+                ]
+            }
         }
-      ],
-      "description": "API endpoints for file uploads"
-    }
-  ],
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "exec": [
-          "// This script runs before every request in the collection.",
-          "// It adds the X-MASTER-KEY header to the request.",
-          "// You can set the 'MASTER_API_KEY' in your Postman environment.",
-          "pm.request.headers.add({",
-          "    key: 'X-MASTER-KEY',",
-          "    value: pm.environment.get('MASTER_API_KEY') || 'SUPER_SECRET_KEY'",
-          "});"
-        ]
-      }
-    }
-  ],
-  "variable": [
-    {
-      "key": "baseUrl",
-      "value": "http://localhost:3000",
-      "type": "default"
-    }
-  ]
+    ],
+    "variable": [
+        {
+            "key": "baseUrl",
+            "value": "http://localhost:3000",
+            "type": "default"
+        }
+    ]
 }


### PR DESCRIPTION
This change allows both the `X-MASTER-KEY` and `X-API-KEY` to be sent in the request body for POST requests, providing more flexibility for users.

The key extraction logic has been centralized into a new helper function to improve code maintainability.

The Swagger documentation, Postman collection, and README have all been updated to reflect these changes.